### PR TITLE
fix: add disconnect vCenter Server prior to host restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+# Release History
+
+## v1.0.0.1007 (Not Released)
+
+Bugfix:
+
+- Added a disconnect from vCenter Server prior toan ESXi host reboot`. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/pull/36)
+
 ## [v1.0.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/releases/tag/v1.0.0)
 
 > Release Date: 2023-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-# CHANGELOG
-
 # Release History
 
-## v1.0.0.1007 (Not Released)
+## v1.1.0 (Not Released)
 
 Bugfix:
 
-- Added a disconnect from vCenter Server prior toan ESXi host reboot`. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/pull/36)
+- Added a disconnect from vCenter Server prior to an ESXi host reboot. [GH-36](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/pull/36)
 
 ## [v1.0.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/releases/tag/v1.0.0)
 

--- a/VMware.CloudFoundation.CertificateManagement.psd1
+++ b/VMware.CloudFoundation.CertificateManagement.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.CertificateManagement.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.0.1006'
+    ModuleVersion = '1.0.0.1007'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.CertificateManagement.psd1
+++ b/VMware.CloudFoundation.CertificateManagement.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.CertificateManagement.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.0.1007'
+    ModuleVersion = '1.1.0.1000'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.CertificateManagement.psm1
+++ b/VMware.CloudFoundation.CertificateManagement.psm1
@@ -1105,9 +1105,9 @@ Function Install-EsxiCertificate {
                     $esxCertificatePem = Get-Content $crtPath -Raw
                     Set-VIMachineCertificate -PemCertificate $esxCertificatePem -VMHost $esxiFqdn -ErrorAction Stop
                     $replacedHosts.Add($esxiFqdn)
-
+                    
                     # Disconnect ESXi host from vCenter Server prior to restarting an ESXi host.
-					Set-EsxiConnectionState -esxiFqdn $esxiFqdn -state "Disconnected" -timeout $timeout
+                    Set-EsxiConnectionState -esxiFqdn $esxiFqdn -state "Disconnected" -timeout $timeout
                     Restart-ESXiHost -esxiFqdn $esxiFqdn -user $($esxiCredential.username) -pass $($esxiCredential.password)
 
                     # Connect to vCenter Server, set the ESXi host connection state, and exit maintenance mode.

--- a/VMware.CloudFoundation.CertificateManagement.psm1
+++ b/VMware.CloudFoundation.CertificateManagement.psm1
@@ -1106,7 +1106,7 @@ Function Install-EsxiCertificate {
                     Set-VIMachineCertificate -PemCertificate $esxCertificatePem -VMHost $esxiFqdn -ErrorAction Stop
                     $replacedHosts.Add($esxiFqdn)
 
-					# Disconnect ESXi host from vCenter prior to restart ESXi host
+                    # Disconnect ESXi host from vCenter Server prior to restarting an ESXi host.
 					Set-EsxiConnectionState -esxiFqdn $esxiFqdn -state "Disconnected" -timeout $timeout
                     Restart-ESXiHost -esxiFqdn $esxiFqdn -user $($esxiCredential.username) -pass $($esxiCredential.password)
 

--- a/VMware.CloudFoundation.CertificateManagement.psm1
+++ b/VMware.CloudFoundation.CertificateManagement.psm1
@@ -970,7 +970,7 @@ Function Restart-ESXiHost {
     # Get the ESXi host uptime before restart.
     $esxiUptime = New-TimeSpan -Start $vmHost.ExtensionData.Summary.Runtime.BootTime.ToLocalTime() -End (Get-Date)
 
-    Restart-VMHost $esxiFqdn
+    Restart-VMHost $esxiFqdn -server $esxiFqdn
     Disconnect-VIServer -server $esxiFqdn -Confirm:$false -WarningAction SilentlyContinue -ErrorAction SilentlyContinue | Out-Null
 
     if ($poll) {
@@ -1105,6 +1105,9 @@ Function Install-EsxiCertificate {
                     $esxCertificatePem = Get-Content $crtPath -Raw
                     Set-VIMachineCertificate -PemCertificate $esxCertificatePem -VMHost $esxiFqdn -ErrorAction Stop
                     $replacedHosts.Add($esxiFqdn)
+
+					# Disconnect ESXi host from vCenter prior to restart ESXi host
+					Set-EsxiConnectionState -esxiFqdn $esxiFqdn -state "Disconnected" -timeout $timeout
                     Restart-ESXiHost -esxiFqdn $esxiFqdn -user $($esxiCredential.username) -pass $($esxiCredential.password)
 
                     # Connect to vCenter Server, set the ESXi host connection state, and exit maintenance mode.


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-certificate-management/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

Fix add a disconnect from vCenter Server prior to ESXi host reboot.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #22

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
